### PR TITLE
fix: ngx-iots-schematics ng-package.json invalid schema

### DIFF
--- a/packages/ngx-iot-schematics/src/library/files/metadata/ng-package.json.template
+++ b/packages/ngx-iot-schematics/src/library/files/metadata/ng-package.json.template
@@ -1,7 +1,5 @@
 {
   "$schema": "<%= relativePathToWorkspaceRoot %>/node_modules/ng-packagr/ng-package.schema.json",
-  "dest": "<%= relativePathToWorkspaceRoot %>/<%= metadatatDistRoot %>",
-  "deleteDestPath": false,
   "lib": {
     "entryFile": "src/<%= entryFile %>.ts"
   }


### PR DESCRIPTION
Fixes the ng-package.json for library generator in iot schematics.