### PR TITLE
feat: schematic for Wizard Steps

### DIFF
--- a/packages/ngx-schematics/src/collection.json
+++ b/packages/ngx-schematics/src/collection.json
@@ -49,6 +49,11 @@
       "factory": "./wizard",
       "schema": "./wizard/schema.json"
     },
+    "wizard-step": {
+      "description": "Generate a new step with a column view.",
+      "factory": "./wizard-step",
+      "schema": "./wizard-step/schema.json"
+    },
     "wizard-create-edit": {
       "description": "Generates a new create edit wizard.",
       "factory": "./wizard-create-edit",

--- a/packages/ngx-schematics/src/collection.json
+++ b/packages/ngx-schematics/src/collection.json
@@ -50,7 +50,7 @@
       "schema": "./wizard/schema.json"
     },
     "wizard-step": {
-      "description": "Generate a new step with a column view.",
+      "description": "Generate a new wizard step.",
       "factory": "./wizard-step",
       "schema": "./wizard-step/schema.json"
     },

--- a/packages/ngx-schematics/src/wizard-step/files/column-view/step-__name@dasherize__/step-__name@dasherize__.component.__style__.template
+++ b/packages/ngx-schematics/src/wizard-step/files/column-view/step-__name@dasherize__/step-__name@dasherize__.component.__style__.template
@@ -1,0 +1,35 @@
+:host {
+    .container {
+        padding: 8px 16px;
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+
+        cmf-core-controls-columnView {
+            flex: 1;
+
+            ::ng-deep .cmf-core-controls-columnViewRow {
+                .row-name-container {
+                    display: flex;
+
+                    .row-name {
+                        display: flex;
+                        flex-direction: column;
+
+                        .row-top {
+                            line-height: calc(var(--normal-increment) + 26px);
+                            font-size: calc(var(--font-size-normal-base) + 13px);
+                            height: 22.5px;
+                        }
+
+                        .row-bottom {
+                            line-height: calc(var(--normal-increment) + 18px);
+                            font-size: calc(var(--font-size-normal-base) + 12px);
+                            height: 22.5px;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/packages/ngx-schematics/src/wizard-step/files/column-view/step-__name@dasherize__/step-__name@dasherize__.component.html.template
+++ b/packages/ngx-schematics/src/wizard-step/files/column-view/step-__name@dasherize__/step-__name@dasherize__.component.html.template
@@ -1,0 +1,50 @@
+<div class="container" cmf-core-controls-validator>
+    <cmf-core-controls-columnView
+        [mainTitle]="columnViewTitle"
+        i18n-leafTitle="@@<%= dasherize(project) %>-wizard-<%= dasherize(wizard) %>#steps.step-<%= dasherize(name) %>.TITLE"
+        leafTitle="<%= nameify(name) %>"
+        [max-columns]="1"
+        [model]="columnViewModel"
+        [columnViewFlexWeight]="1"
+        [showActionAdd]="true"
+        [showActionRemove]="true"
+        [showColumnsHeader]="true"
+        [preSelectFirstRow]="true"
+        (selected)="onSelectedRow($event)"
+        (add)="onAddRow($event)"
+        (remove)="onRemoveRow($event)"
+        #columnView>
+
+        <leaf-content>
+            @if (selectedLeaf) {
+                <div class="content"> 
+                    <cmf-core-business-controls-propertyContainer>
+                        <!-- Entity to select (e.g. Area) -->
+                        <cmf-core-business-controls-propertyEditor
+                            i18n-label="@@<%= dasherize(project) %>-wizard-<%= dasherize(wizard) %>#steps.step-<%= dasherize(name) %>.ENTITY_TO_SELECT_LABEL"
+                            label="Entity to Select"
+                            valueType="ReferenceType"
+                            valueReferenceType="EntityType"
+                            referenceTypeName="Area"
+                            [required]="true"
+                            [value]="$any(selectedLeaf.tag).entity"
+                            (valueChange)="onEntitySelectionChange($event)">
+                        </cmf-core-business-controls-propertyEditor>
+
+                        @if (selectedLeaf?.tag?.entity) {
+                            <!-- Entity Description -->
+                            <cmf-core-business-controls-entityPropertyViewer
+                                [instance]="selectedLeaf.tag.entity"
+                                i18n-label="@@<%= dasherize(project) %>-wizard-<%= dasherize(wizard) %>#steps.step-<%= dasherize(name) %>.ENTITY_DESCRIPTION"
+                                label="Entity Description"
+                                property="Description"
+                                data-tag="EntityDescription">
+                            </cmf-core-business-controls-entityPropertyViewer>
+                        }
+
+                    </cmf-core-business-controls-propertyContainer>
+                </div>
+            }
+        </leaf-content>
+    </cmf-core-controls-columnView>
+</div>

--- a/packages/ngx-schematics/src/wizard-step/files/column-view/step-__name@dasherize__/step-__name@dasherize__.component.ts.template
+++ b/packages/ngx-schematics/src/wizard-step/files/column-view/step-__name@dasherize__/step-__name@dasherize__.component.ts.template
@@ -1,0 +1,335 @@
+import {
+    Component,
+    forwardRef,
+    OnInit,
+    input,
+    output,
+    inject
+} from '@angular/core';
+
+import {
+    CommonModule
+} from '@angular/common';
+
+import {
+    Cmf
+} from 'cmf-lbos';
+
+import {
+    CustomizableComponent,
+    HOST_VIEW_COMPONENT,
+    ResultMessageType,
+    UtilService
+} from 'cmf-core';
+
+import {
+    ValidatorModule,
+    OnValidateArgs,
+    ColumnViewModule,
+    ColumnViewSelectedArgs,
+    ColumnViewLeaf,
+    ColumnViewModel,
+    ColumnViewAddArgs,
+    ColumnViewLeafTag,
+    ColumnViewItem,
+    ColumnViewRemoveArgs,
+    ColumnViewLeafState
+} from 'cmf-core-controls';
+
+import {
+    PropertyViewerModule,
+    PropertyEditorModule,
+    PropertyContainerModule,
+    EntityPropertyViewerModule
+} from 'cmf-core-business-controls';
+
+
+/**
+ * <%= classify(name) %> tag type used in ColumnView elements
+ */
+type <%= classify(name) %>Tag = ColumnViewLeafTag & { entity: Cmf.Foundation.BusinessObjects.Entity };
+
+
+/**
+ * @whatItDoes
+ *
+ * Please provide a meaningful description of this component
+ * Try to answer these questions:
+ * * What is it?
+ * * What it does?
+ * * How does it behave with different sizes?
+ * * Does it retrieve data from any external source (server, local database, text file, etc...)?
+ *
+ * @howToUse
+ *
+ * This component is used with the inputs and outputs mentioned below.
+ *
+ * Besides the description above, please complement it with a meaningful description of this component that answer these questions:
+ * * How to use it?
+ * * Where and When to use it?
+ *
+ * ### Inputs
+ * `string` : **name** - The name of this component
+ * `number` : **value** - The value of this component
+ *
+ * ### Outputs
+ * `string` : **onNameChange** - When the name of the component change, this output emits the new name
+ * `number` : **onValueChange** - When the value of the component change, this output emits the new value
+ *
+ * ### Example
+ * To use the component, assume this HTML Template as an example:
+ *
+ * ```HTML
+ * <<%= dasherize(project) %>-page-<%= dasherize(name) %>></<%= dasherize(project) %>-page-<%= dasherize(name) %>>
+ * ```
+ *
+ * ### _NOTES_
+ * (optional, Provide additional notes here)
+ *
+ * @description
+ *
+ * ## <%= classify(name) %>Component Component
+ *
+ * ### Dependencies
+ *
+ * #### Components
+ * * ComponentA : `package`
+ * * ComponentB : `package`
+ *
+ * #### Services
+ * * ServiceA : `package`
+ * * ServiceB : `package`
+ *
+ * #### Directives
+ * * DirectiveA : `package`
+ * * DirectiveB : `package`
+ *
+ */
+@Component({
+    standalone: true,
+    selector: '<%= dasherize(project) %>-wizard-<%= dasherize(wizard) %>-step-<%= dasherize(name) %>',
+    imports: [
+        CommonModule,
+        ValidatorModule,
+        ColumnViewModule,
+        PropertyViewerModule,
+        PropertyEditorModule,
+        PropertyContainerModule,
+        EntityPropertyViewerModule
+    ],
+    templateUrl: './step-<%= dasherize(name) %>.component.html',
+    <% if (style !== 'none') { %>styleUrl: './step-<%= dasherize(name) %>.component.<%= style %>',<% } %>
+    viewProviders: [{ provide: HOST_VIEW_COMPONENT, useExisting: forwardRef(() => Step<%= classify(name) %>Component) }]
+})
+export class Step<%= classify(name) %>Component extends CustomizableComponent implements OnInit {
+
+    /**
+     * Instance input
+     * @Input({ required: true })
+     */
+    public instance = input.required<Cmf.<%= namespace %>.BusinessObjects.<%= classify(entityType) %>>();
+
+    /**
+    * Column view title
+    */
+    public columnViewTitle: string = $localize`:@@<%= dasherize(project) %>-wizard-<%= dasherize(wizard) %>#steps.step-<%= dasherize(name) %>.COLUMN_VIEW_TITLE:Materials`;
+
+    /**
+     * Selected Entities
+     */
+    public selectedEntities: Cmf.Foundation.BusinessObjects.Entity[] = [];
+
+    /**
+     * Selected Leaf
+     */
+    public selectedLeaf: ColumnViewLeaf<<%= classify(name) %>Tag> | null = null;
+
+    /**
+     * Model used by the ColumnView component that is shown on the template.
+     */
+    public columnViewModel: ColumnViewModel | null = null;
+
+    /**
+     * The entities changed event
+     * @Output()
+     */
+    public entitiesChanged = output<Cmf.Foundation.BusinessObjects.Entity[]>();
+
+    /**
+     * Services to inject
+     */
+    protected util = inject(UtilService);
+
+    /**
+     * Gets the HTML Name for Column View Row
+     * @param name row name
+     * @param description row description
+     */
+    private getHTMLForName(name: string, description: string) {
+        let html: string;
+
+        if (description) {
+            html =
+                `${name
+                    ? `<div class="row-top">${name}</div>`
+                    : `<div class="row-top cmf-placeholder-alike">${
+                        $localize`:@@<%= dasherize(project) %>-wizard-<%= dasherize(wizard) %>#steps.step-<%= dasherize(name) %>.NEW_ITEM:\
+New Item`}</div>`}
+                <div class="row-bottom">${description}</div>`;
+        } else if (name) {
+            html = `<div>${name}</div>`;
+        } else {
+            html = `<div class="cmf-placeholder-alike">${
+                $localize`:@@<%= dasherize(project) %>-wizard-<%= dasherize(wizard) %>#steps.step-<%= dasherize(name) %>.NEW_ITEM:\
+New Item`}</div>`;
+        }
+
+        html = `<div class="row-name-container"><div class="row-name">${html}</div></div>`;
+
+        return html;
+    }
+
+    /**
+     * Build an empty leaf
+     * @returns new leaf
+     */
+    private buildEmptyLeaf(): ColumnViewLeaf<<%= classify(name) %>Tag> {
+        const leafTag: <%= classify(name) %>Tag = {
+            id: this.util._.uniqueId('fields_'),
+            state: ColumnViewLeafState.Added,
+            valid: true,
+            entity: null
+        };
+
+        const newLeaf: ColumnViewLeaf<<%= classify(name) %>Tag> = {
+            id: this.util._.uniqueId('row_'),
+            name: this.getHTMLForName(null, null),
+            tag: leafTag,
+            value: null,
+            canRemove: true
+        };
+
+        return newLeaf;
+    }
+
+    /**
+     * Builds column view model
+     */
+    private buildColumnViewModel(): void {
+        this.columnViewModel = {
+            rootNode: {
+                id: 'root',
+                name: $localize`:@@<%= dasherize(project) %>-wizard-<%= dasherize(wizard) %>#steps.step-<%= dasherize(name) %>.ITEMS:Items`,
+                value: $localize`:@@<%= dasherize(project) %>-wizard-<%= dasherize(wizard) %>#steps.step-<%= dasherize(name) %>.VALUE:Value`,
+                children: [
+                    this.buildEmptyLeaf() // Only needed if we want the column view to start with an empty row
+                ]
+            }
+        };
+    }
+
+
+    /**
+     * Callback used for the "selected" sent by the ColumnView component that
+     * is used to display the sub-materials that will be detached by this
+     * Detach wizard.
+     *
+     * @param event The payload sent by the "(selected)" event of the ColumnView component.
+     * @returns Nothing.
+     */
+    public onSelectedRow(event: ColumnViewSelectedArgs): void {
+        this.selectedLeaf = event?.selectedRow?.rootNode as ColumnViewLeaf;
+    }
+
+    /**
+     * Adds a new row to the ColumnView
+     * @param event ColumnViewAddArgs
+     */
+    public onAddRow(event: ColumnViewAddArgs<<%= classify(name) %>Tag>): void {
+        const newLeaf: ColumnViewLeaf<<%= classify(name) %>Tag> = this.buildEmptyLeaf();
+
+        (this.columnViewModel.rootNode.children as ColumnViewItem[]).push(newLeaf);
+
+        event.add(true);
+
+        this.selectedLeaf = newLeaf;
+    }
+
+    /**
+     * Removes the selected row from the ColumnView
+     * @param event ColumnViewRemoveArgs
+     */
+    public onRemoveRow(event: ColumnViewRemoveArgs<<%= classify(name) %>Tag>) {
+        const entity = event.selectedRow.rootNode.tag.entity;
+        // Remove old entity from the selected list
+        if (entity != null) {
+            const oldEntityIndex = this.selectedEntities.findIndex(x => x.Id === entity.Id);
+            this.selectedEntities.splice(oldEntityIndex, 1);
+        }
+
+        event.remove(true);
+
+        if (this.columnViewModel.rootNode?.children?.length === 0 ||
+            (this.selectedLeaf?.tag?.entity?.Id != null && this.selectedLeaf?.tag?.entity?.Id === entity?.Id)) {
+            this.selectedLeaf = null;
+        }
+
+        this.entitiesChanged.emit(this.selectedEntities);
+    }
+
+    /**
+     * Entity selection change event handler
+     * @param newEntity new value for the entity
+     */
+    public onEntitySelectionChange(newEntity: Cmf.Foundation.BusinessObjects.Entity) {
+        if (this.selectedLeaf == null) {
+            return;
+        }
+
+        // Remove old entity from the selected list
+        if (this.selectedLeaf.tag.entity != null) {
+            const oldMaterialIndex = this.selectedEntities.findIndex(x => x.Id === this.selectedLeaf.tag.entity.Id);
+            this.selectedEntities.splice(oldMaterialIndex, 1);
+        }
+
+        // Add new entity to the selected list
+        if (newEntity != null) {
+            this.selectedEntities.push(newEntity);
+        }
+
+        this.selectedLeaf.tag.entity = newEntity;
+
+
+        this.selectedLeaf.name = this.getHTMLForName(newEntity?.Name, newEntity?.Description);
+        this.selectedLeaf.value = newEntity?.Id;
+    }
+
+    /**
+     * The validation for this component
+     *
+     * @param validationContext The validation context.
+     */
+    public onValidate(validationContext: OnValidateArgs): Promise<boolean> {
+        if (this.selectedEntities == null || this.selectedEntities.length === 0) {
+            if (validationContext.resultMessages == null) {
+                validationContext.resultMessages = [];
+            }
+
+            validationContext.resultMessages.push({
+                type: ResultMessageType.Error,
+                message: $localize`:@@<%= dasherize(project) %>-wizard-<%= dasherize(wizard) %>#steps.step-<%= dasherize(name) %>.ERROR_NO_ENTITY_SELECTED:It's \
+necessary to select at least one Entity to perform the operation.`,
+            });
+            return Promise.resolve(false);
+        }
+
+        return Promise.resolve(true);
+    }
+
+    /**
+     * OnInit event handler
+     */
+    public ngOnInit(): void {
+        this.buildColumnViewModel();
+    }
+}

--- a/packages/ngx-schematics/src/wizard-step/index.ts
+++ b/packages/ngx-schematics/src/wizard-step/index.ts
@@ -1,0 +1,99 @@
+import {
+  apply,
+  applyTemplates,
+  chain,
+  filter,
+  mergeWith,
+  move,
+  noop,
+  Rule,
+  SchematicContext,
+  SchematicsException,
+  Tree,
+  url
+} from '@angular-devkit/schematics';
+import { readWorkspace } from '@schematics/angular/utility';
+import inquirer, { ListQuestion, InputQuestion } from 'inquirer';
+import { getDefaultPath, parseName, strings } from '@criticalmanufacturing/schematics-devkit';
+import { Schema } from './schema';
+
+export default function (_options: Schema): Rule {
+  return async (tree: Tree, _context: SchematicContext) => {
+    if (!_options.namespace) {
+      const namespaceQuestion: ListQuestion = {
+        type: 'list',
+        name: 'namespace',
+        message: 'What is the business objects namespace of the entity type?',
+        choices: ['Foundation', 'Navigo', 'Other (specify)']
+      };
+
+      _options.namespace = (await inquirer.prompt([namespaceQuestion])).namespace;
+
+      if (_options.namespace!.startsWith('Other')) {
+        const namespaceQuestion: InputQuestion = {
+          type: 'input',
+          name: 'namespace',
+          message: 'Namespace'
+        };
+
+        _options.namespace = (await inquirer.prompt([namespaceQuestion])).namespace;
+      }
+    }
+
+    const workspace = await readWorkspace(tree);
+    const project = workspace.projects.get(_options.project);
+
+    if (!project) {
+      throw new SchematicsException(`Project "${_options.project}" does not exist.`);
+    }
+
+    if (_options.path === undefined) {
+      _options.path = getDefaultPath(project);
+    }
+
+    if (!_options.name) {
+      throw new SchematicsException(`Action name is required`);
+    }
+
+    if (!_options.wizard) {
+      throw new SchematicsException(`Wizard name is required`);
+    }
+
+    if (!_options.entityType) {
+      throw new SchematicsException(`Entity Type name is required`);
+    }
+
+    if (!_options.namespace) {
+      throw new SchematicsException(`Entity Type namespace is required`);
+    }
+
+    if (!_options.stepType) {
+      throw new SchematicsException(`Step Type is required`);
+    }
+
+    if (_options.stepType !== 'Column View') {
+      throw new SchematicsException(`Step Type not supported`);
+    }
+
+    const parsedPath = parseName(_options.path, _options.name);
+    _options.name = parsedPath.name;
+    _options.path = parsedPath.path;
+
+    const skipStyleFile = _options.style === 'none';
+
+    const templateSource = apply(url('./files/column-view'), [
+      skipStyleFile ? filter((path) => !path.endsWith('.__style__.template')) : noop(),
+      applyTemplates({
+        ...strings,
+        ..._options
+      }),
+      move(parsedPath.path)
+    ]);
+
+    if (templateSource == null) {
+      throw new SchematicsException(`Step Type is not valid`);
+    }
+
+    return chain([mergeWith(templateSource)]);
+  };
+}

--- a/packages/ngx-schematics/src/wizard-step/index_spec.ts
+++ b/packages/ngx-schematics/src/wizard-step/index_spec.ts
@@ -1,0 +1,165 @@
+import { strings } from '@criticalmanufacturing/schematics-devkit';
+import { SchematicTestRunner, UnitTestTree } from '@angular-devkit/schematics/testing';
+
+describe('Generate Step', () => {
+  const schematicRunner = new SchematicTestRunner(
+    '@criticalmanufacturing/ngx-schematics',
+    require.resolve('../collection.json')
+  );
+
+  const workspaceOptions = {
+    name: 'workspace',
+    newProjectRoot: 'projects',
+    version: '10.0.0'
+  };
+
+  const appOptions = {
+    name: 'app',
+    inlineStyle: false,
+    inlineTemplate: false,
+    routing: false,
+    skipTests: false,
+    skipPackageJson: false
+  };
+
+  const libraryOptions = {
+    name: 'testlib',
+    skipPackageJson: false,
+    skipTsConfig: false,
+    skipInstall: false
+  };
+
+  const stepOptions = {
+    name: 'ParentMaterials',
+    wizard: 'TransferMaterialsToMultiple',
+    stepType: 'Column View',
+    entityType: 'Material',
+    project: libraryOptions.name,
+    namespace: 'Navigo'
+  };
+
+  const stepPath = `projects/${libraryOptions.name}/src/lib/step-${strings.dasherize(
+    stepOptions.name
+  )}`;
+
+  let appTree: UnitTestTree;
+
+  beforeEach(async () => {
+    appTree = await schematicRunner.runExternalSchematic(
+      '@schematics/angular',
+      'workspace',
+      workspaceOptions
+    );
+
+    appTree = await schematicRunner.runExternalSchematic(
+      '@schematics/angular',
+      'application',
+      appOptions,
+      appTree
+    );
+
+    appTree = await schematicRunner.runSchematic('library', libraryOptions, appTree);
+  });
+
+  it('should create the step files', async () => {
+    const tree = await schematicRunner.runSchematic('wizard-step', stepOptions, appTree);
+
+    const dasherizedStepName = strings.dasherize(stepOptions.name);
+
+    expect(tree.getDir(stepPath).subfiles).toEqual(
+      jasmine.arrayContaining([
+        `step-${dasherizedStepName}.component.less`,
+        `step-${dasherizedStepName}.component.html`,
+        `step-${dasherizedStepName}.component.ts`
+      ])
+    );
+  });
+
+  it('should create the step style file with other extension', async () => {
+    const options = { ...stepOptions, style: 'css' };
+
+    const tree = await schematicRunner.runSchematic('wizard-step', options, appTree);
+
+    const dasherizedStepName = strings.dasherize(stepOptions.name);
+
+    expect(tree.getDir(stepPath).subfiles).toEqual(
+      jasmine.arrayContaining([`step-${dasherizedStepName}.component.css`])
+    );
+  });
+
+  it('should not create the step style file', async () => {
+    const options = { ...stepOptions, style: 'none' };
+
+    const tree = await schematicRunner.runSchematic('wizard-step', options, appTree);
+
+    const files = tree.getDir(stepPath).subfiles;
+
+    expect(files).toHaveSize(2);
+    expect(files).toEqual(
+      jasmine.arrayContaining([
+        `step-${strings.dasherize(stepOptions.name)}.component.html`,
+        `step-${strings.dasherize(stepOptions.name)}.component.ts`
+      ])
+    );
+  });
+
+  it('should have the Component decorator with properties selector, templateUrl, styleUrl, and viewProviders', async () => {
+    const tree = await schematicRunner.runSchematic('wizard-step', stepOptions, appTree);
+
+    const stepContent = tree.readContent(
+      `${stepPath}/step-${strings.dasherize(stepOptions.name)}.component.ts`
+    );
+    expect(stepContent).toMatch(/@Component\(/);
+    expect(stepContent).toContain(`standalone: true`);
+    expect(stepContent).toContain(
+      `selector: '${strings.dasherize(stepOptions.project)}-wizard-${strings.dasherize(stepOptions.wizard)}-step-${strings.dasherize(
+        stepOptions.name
+      )}'`
+    );
+    expect(stepContent).toContain(
+      `templateUrl: './step-${strings.dasherize(stepOptions.name)}.component.html'`
+    );
+    expect(stepContent).toContain(
+      `styleUrl: './step-${strings.dasherize(stepOptions.name)}.component.less'`
+    );
+    expect(stepContent).toContain(
+      `viewProviders: [{ provide: HOST_VIEW_COMPONENT, useExisting: forwardRef(() => Step${strings.classify(
+        stepOptions.name
+      )}Component) }]`
+    );
+  });
+
+  it('should extend CustomizableComponent', async () => {
+    const tree = await schematicRunner.runSchematic('wizard-step', stepOptions, appTree);
+
+    const stepContent = tree.readContent(
+      `${stepPath}/step-${strings.dasherize(stepOptions.name)}.component.ts`
+    );
+    expect(stepContent).toContain(
+      `export class Step${strings.classify(
+        stepOptions.name
+      )}Component extends CustomizableComponent`
+    );
+  });
+
+  it('should implement OnInit', async () => {
+    const tree = await schematicRunner.runSchematic('wizard-step', stepOptions, appTree);
+
+    const stepContent = tree.readContent(
+      `${stepPath}/step-${strings.dasherize(stepOptions.name)}.component.ts`
+    );
+    expect(stepContent).toContain(`implements OnInit`);
+    expect(stepContent).toContain(`public ngOnInit(): void {`);
+  });
+
+  it('should inject the PageBag, UtilService, and EntityTypeService', async () => {
+    const tree = await schematicRunner.runSchematic('wizard-step', stepOptions, appTree);
+
+    const stepContent = tree.readContent(
+      `${stepPath}/step-${strings.dasherize(stepOptions.name)}.component.ts`
+    );
+
+    expect(stepContent).toContain('protected util = inject(UtilService)');
+    expect(stepContent).not.toContain('constructor');
+  });
+});

--- a/packages/ngx-schematics/src/wizard-step/schema.json
+++ b/packages/ngx-schematics/src/wizard-step/schema.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "SchematicsWizardStep",
+  "title": "Wizard Step Options Schema",
+  "type": "object",
+  "properties": {
+    "path": {
+      "type": "string",
+      "format": "path",
+      "$default": {
+        "$source": "workingDirectory"
+      },
+      "description": "The path at which to create the component file, relative to the current workspace. Default is a folder with the same name as the component in the project root.",
+      "visible": false
+    },
+    "project": {
+      "type": "string",
+      "description": "The name of the project.",
+      "$default": {
+        "$source": "projectName"
+      }
+    },
+    "name": {
+      "type": "string",
+      "description": "The name of the step.",
+      "$default": {
+        "$source": "argv",
+        "index": 0
+      },
+      "x-prompt": "What name would you like to use for the step?"
+    },
+    "wizard": {
+      "type": "string",
+      "description": "The name of the wizard.",
+      "$default": {
+        "$source": "argv",
+        "index": 0
+      },
+      "x-prompt": "What's the name of the parent wizard?"
+    },
+    "stepType": {
+      "type": "string",
+      "description": "The step type to create.",
+      "default": "Column View",
+      "enum": ["Column View"],
+      "x-prompt": {
+        "message": "What is the step type you want?",
+        "type": "list",
+        "items": ["Column View"]
+      }
+    },
+    "entityType": {
+      "type": "string",
+      "description": "The name of the entity type to receive as input.",
+      "x-prompt": "What is the name of the entity type to receive as input?"
+    },
+    "namespace": {
+      "type": "string",
+      "description": "The namespace of the entity type."
+    },
+    "style": {
+      "description": "The file extension or preprocessor to use for style files, or 'none' to skip generating the style file.",
+      "type": "string",
+      "default": "less",
+      "enum": ["css", "scss", "sass", "less", "none"]
+    }
+  },
+  "required": ["name", "entityType", "stepType"]
+}

--- a/packages/ngx-schematics/src/wizard-step/schema.ts
+++ b/packages/ngx-schematics/src/wizard-step/schema.ts
@@ -1,0 +1,42 @@
+export interface Schema {
+  /**
+   * The path at which to create the component file, relative to the current workspace.
+   * Default is a folder with the same name as the component in the project root.
+   */
+  path: string;
+
+  /**
+   * The name of the project.
+   */
+  project: string;
+
+  /**
+   * The name of the step.
+   */
+  name: string;
+
+  /**
+   * The name of the parent wizard.
+   */
+  wizard: string;
+
+  /**
+   * The type of step
+   */
+  stepType: string;
+
+  /**
+   * The name of the entity type to be performed.
+   */
+  entityType: string;
+
+  /**
+   * The namespace of the entity type.
+   */
+  namespace?: string;
+
+  /**
+   * The file extension or preprocessor to use for style files, or 'none' to skip generating the style file.
+   */
+  style: string;
+}


### PR DESCRIPTION
This PR introduces a new Angular schematic for generating wizard steps.

Currently, it only supports one step type: Column View, where the step will display a Column View for the user to select elements. However, the goal is to expand it to support additional commonly used step types in the future.

To enable this flexibility, the schematic prompts the user to select the type of step they want to generate. Over time, we can extend this by adding more options to the enum, allowing this schematic to support more step types.