### PR TITLE
Add localizationfiles so translations work 

### DIFF
--- a/packages/ngx-schematics/src/ng-add/files/config.json.template
+++ b/packages/ngx-schematics/src/ng-add/files/config.json.template
@@ -32,7 +32,7 @@
       "startupCulture": "<%= startupCulture %>",
       "startupTheme": "<%= startupTheme %>"
     },
-    "localizationFiles": ""
+    "localizationFiles": "assets"
   },
   "cacheId": "",
   "version": "0.0.1"


### PR DESCRIPTION
When scaffolding a custom ui on a v10+ project translations stop working because localizationFiles config is empty 