### PR TITLE
feat: add migration for LboService.call method

### DIFF
--- a/packages/ngx-schematics/src/collection.json
+++ b/packages/ngx-schematics/src/collection.json
@@ -70,7 +70,7 @@
       "schema": "./doc/schema.json"
     },
     "update-12-0-0": {
-      "description": "Updates config.json themes.",
+      "description": "Runs code migrations for v12.0.0",
       "factory": "./migrations/update-12-0-0",
       "schema": "./migrations/update-12-0-0/schema.json"
     }

--- a/packages/ngx-schematics/src/migrations/update-12-0-0/index.ts
+++ b/packages/ngx-schematics/src/migrations/update-12-0-0/index.ts
@@ -3,6 +3,7 @@ import { getDefaultApplicationProject } from '@criticalmanufacturing/schematics-
 import { updateI18nExtract } from '@criticalmanufacturing/schematics-devkit/rules';
 import { migrate as migrateSuperExpressions } from '@criticalmanufacturing/schematics-devkit/migrations/update-12-0-0-super';
 import { migrate as migrateStandalone } from '@criticalmanufacturing/schematics-devkit/migrations/update-12-0-0-standalone';
+import { migrate as migrateLboCall } from '@criticalmanufacturing/schematics-devkit/migrations/update-12-0-0-lbo-call';
 import { updateThemesInConfigFile } from './themes-update';
 import { updateAppSettings } from './configs-update';
 import { addWorkers } from '../../ng-add/rules/add-workers';
@@ -20,6 +21,7 @@ export default function (): Rule {
       updateAppSettings({ project }),
       migrateSuperExpressions({ path: './' }),
       migrateStandalone({ path: './' }),
+      migrateLboCall({ path: './' }),
       addWorkers({ project }),
       updateI18nExtract({ project, version: '12' })
     ]);

--- a/packages/schematics-devkit/migrations/collection.json
+++ b/packages/schematics-devkit/migrations/collection.json
@@ -10,6 +10,11 @@
       "description": "Updates NgModules and stadnalone components to use standalone components.",
       "factory": "./update-12-0-0-standalone#migrate",
       "schema": "./update-12-0-0-standalone/schema.json"
+    },
+    "update-lbo-call": {
+      "description": "Updates usage of LBOService's call function to the new signature.",
+      "factory": "./update-12-0-0-lbo-call#migrate",
+      "schema": "./update-12-0-0-lbo-call/schema.json"
     }
   }
 }

--- a/packages/schematics-devkit/migrations/migration.ts
+++ b/packages/schematics-devkit/migrations/migration.ts
@@ -47,9 +47,8 @@ export async function createMigrationProject(
       return;
     }
 
-    tsProject.addSourceFilesAtPaths(
-      relative(path, srcRoot).startsWith('..') ? join(path, '**/*.ts') : join(srcRoot, '**/*.ts')
-    );
+    // glob pattern: add .ts, but exclude .d.ts
+    tsProject.addSourceFilesAtPaths(['**/*.ts', '!**/*.d.ts', '!**/node_modules/**']);
   });
 
   return tsProject;

--- a/packages/schematics-devkit/migrations/update-12-0-0-lbo-call/index.ts
+++ b/packages/schematics-devkit/migrations/update-12-0-0-lbo-call/index.ts
@@ -1,0 +1,255 @@
+import { Rule, Tree } from '@angular-devkit/schematics';
+import { Schema } from './schema';
+import { tryGetRoot } from '../../src/workspace';
+import { join, relative } from 'node:path';
+import { createMigrationProject } from '../migration';
+import { Node, SourceFile, Symbol, SyntaxKind, Type } from 'ts-morph';
+import ora from 'ora';
+
+const CMF_CORE_PACKAGE = 'cmf-core';
+const LBO_SERVICE_IMPORT = 'LboService';
+const CALL_METHOD = 'call';
+
+/**
+ * Checks if two ts-morph symbols point to the same declaration.
+ */
+function isSameSymbol(left: Symbol | undefined, right: Symbol | undefined): boolean {
+  if (!left || !right) {
+    return false;
+  }
+
+  const leftDecl = left.getDeclarations()[0];
+  const rightDecl = right.getDeclarations()[0];
+
+  if (!leftDecl || !rightDecl) {
+    return false;
+  }
+
+  return (
+    leftDecl.getSourceFile().getFilePath() === rightDecl.getSourceFile().getFilePath() &&
+    leftDecl.getStart() === rightDecl.getStart()
+  );
+}
+
+/**
+ * Validates whether a type resolves to LboService directly or through composed types.
+ */
+function isLboReceiverType(type: Type, lboSymbol: Symbol): boolean {
+  const typesToCheck = [type, type.getApparentType()];
+  for (const currentType of typesToCheck) {
+    const directSymbol = currentType.getSymbol();
+    if (isSameSymbol(directSymbol, lboSymbol)) {
+      return true;
+    }
+
+    const baseTypes = currentType.getBaseTypes();
+    if (baseTypes.some((baseType) => isSameSymbol(baseType.getSymbol(), lboSymbol))) {
+      return true;
+    }
+
+    const unionTypes = currentType.getUnionTypes();
+    if (unionTypes.some((unionType) => isLboReceiverType(unionType, lboSymbol))) {
+      return true;
+    }
+
+    const intersectionTypes = currentType.getIntersectionTypes();
+    if (
+      intersectionTypes.some((intersectionType) => isLboReceiverType(intersectionType, lboSymbol))
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Gets the in-file identifier node used for the LboService import, supporting aliases.
+ */
+function getLboImportNode(source: SourceFile): Node | undefined {
+  const lboImport = source
+    .getImportDeclarations()
+    .find((declaration) => declaration.getModuleSpecifierValue() === CMF_CORE_PACKAGE)
+    ?.getNamedImports()
+    .find((namedImport) => namedImport.getName() === LBO_SERVICE_IMPORT);
+
+  return (lboImport?.getAliasNode() ?? lboImport?.getNameNode())?.asKind(SyntaxKind.Identifier);
+}
+
+/**
+ * Resolves the symbol for the imported LboService identifier.
+ */
+function getLboSymbol(lboImportNode: Node | undefined): Symbol | undefined {
+  if (!lboImportNode) {
+    return;
+  }
+
+  return lboImportNode.getSymbol()?.getAliasedSymbol() ?? lboImportNode.getSymbol();
+}
+
+/**
+ * Checks whether an initializer is an inject(...) call targeting LboService.
+ */
+function isInjectLboInitializer(initializer: Node | undefined, lboSymbol: Symbol): boolean {
+  const callExp = initializer?.asKind(SyntaxKind.CallExpression);
+  if (!callExp || callExp.getExpression().getText() !== 'inject') {
+    return false;
+  }
+
+  const dependency = callExp.getArguments()[0]?.asKind(SyntaxKind.Identifier);
+  if (!dependency) {
+    return false;
+  }
+
+  const dependencySymbol = dependency.getSymbol()?.getAliasedSymbol() ?? dependency.getSymbol();
+  return isSameSymbol(dependencySymbol, lboSymbol);
+}
+
+/**
+ * Checks whether a declaration is typed as LboService or initialized via inject(LboService).
+ */
+function isDeclarationTypedAsLbo(declaration: Node, lboSymbol: Symbol): boolean {
+  const typeNode =
+    declaration.asKind(SyntaxKind.PropertyDeclaration)?.getTypeNode() ??
+    declaration.asKind(SyntaxKind.Parameter)?.getTypeNode() ??
+    declaration.asKind(SyntaxKind.VariableDeclaration)?.getTypeNode();
+
+  if (typeNode && isLboReceiverType(typeNode.getType(), lboSymbol)) {
+    return true;
+  }
+
+  const initializer =
+    declaration.asKind(SyntaxKind.PropertyDeclaration)?.getInitializer() ??
+    declaration.asKind(SyntaxKind.VariableDeclaration)?.getInitializer();
+
+  return isInjectLboInitializer(initializer, lboSymbol);
+}
+
+/**
+ * Checks whether the receiver declaration can be resolved as LboService.
+ */
+function isReceiverDeclarationLbo(receiver: Node, lboSymbol: Symbol): boolean {
+  const receiverPropertyAccess = receiver.asKind(SyntaxKind.PropertyAccessExpression);
+  const receiverSymbol =
+    receiver.asKind(SyntaxKind.Identifier)?.getSymbol() ??
+    receiverPropertyAccess?.getNameNode().getSymbol();
+
+  if (!receiverSymbol) {
+    return false;
+  }
+
+  return receiverSymbol
+    .getDeclarations()
+    .some((declaration) => isDeclarationTypedAsLbo(declaration, lboSymbol));
+}
+
+/**
+ * Returns the receiver of a call expression when it is a *.call(...) invocation.
+ */
+function getCallReceiver(callExpression: Node): Node | undefined {
+  const expression = callExpression
+    .asKind(SyntaxKind.CallExpression)
+    ?.getExpression()
+    .asKind(SyntaxKind.PropertyAccessExpression);
+
+  if (!expression || expression.getName() !== CALL_METHOD) {
+    return;
+  }
+
+  return expression.getExpression();
+}
+
+/**
+ * Determines if a call receiver should be treated as LboService.
+ */
+function shouldMigrateCall(receiver: Node, lboServiceSymbol: Symbol): boolean {
+  return (
+    isLboReceiverType(receiver.getType(), lboServiceSymbol) ||
+    isReceiverDeclarationLbo(receiver, lboServiceSymbol)
+  );
+}
+
+/**
+ * Determines if a call receiver should be migrated against any discovered LboService symbol.
+ */
+function shouldMigrateCallForAnyLboServiceSymbol(
+  receiver: Node,
+  lboServiceSymbols: Symbol[]
+): boolean {
+  return lboServiceSymbols.some((lboServiceSymbol) =>
+    shouldMigrateCall(receiver, lboServiceSymbol)
+  );
+}
+
+/**
+ * Updates usage of LboService.call to no longer invoke with a generic type argument
+ * @param options Schema options
+ * @returns Schematics Rule
+ */
+export function migrate(options: Schema): Rule {
+  return async (tree: Tree) => {
+    const spinner = ora({
+      text: 'Migrating LboService call method...'
+    }).start();
+
+    try {
+      // Get the root directory and construct the base path
+      const rootDir = tryGetRoot();
+      const basePath = process.cwd();
+      const path = join(basePath, options.path ?? './');
+
+      // Exit if the root directory is not found or the path is outside the root
+      if (!rootDir || relative(rootDir, path).startsWith('..')) {
+        return;
+      }
+
+      // Create a migration project
+      const migrationProj = await createMigrationProject(tree, { rootDir, path });
+
+      // Discover LboService symbols across the project so files without direct imports can still be migrated.
+      const lboServiceSymbols = migrationProj
+        .getSourceFiles()
+        .map((source) => getLboSymbol(getLboImportNode(source)))
+        .filter((symbol): symbol is Symbol => Boolean(symbol));
+
+      if (lboServiceSymbols.length === 0) {
+        return;
+      }
+
+      // Set to keep track of modified files
+      const modifiedFiles = new Set<SourceFile>();
+
+      // Iterate through all source files in the project
+      migrationProj.getSourceFiles().forEach((source) => {
+        source.getDescendantsOfKind(SyntaxKind.CallExpression).forEach((callExpression) => {
+          const receiver = getCallReceiver(callExpression);
+          if (!receiver) {
+            return;
+          }
+
+          if (!shouldMigrateCallForAnyLboServiceSymbol(receiver, lboServiceSymbols)) {
+            return;
+          }
+
+          const typeArgs = callExpression.getTypeArguments();
+          if (typeArgs.length > 0) {
+            callExpression.removeTypeArgument(0);
+            modifiedFiles.add(callExpression.getSourceFile());
+          }
+        });
+
+        // Save changed files for this source.
+        modifiedFiles.forEach((modifiedSource) => {
+          tree.overwrite(
+            relative(rootDir, modifiedSource.getFilePath()),
+            modifiedSource.getFullText()
+          );
+        });
+      });
+      spinner.succeed('LboService call method migration completed.');
+    } catch (error) {
+      spinner.fail('LboService call method migration failed.');
+      throw error;
+    }
+  };
+}

--- a/packages/schematics-devkit/migrations/update-12-0-0-lbo-call/index_spec.ts
+++ b/packages/schematics-devkit/migrations/update-12-0-0-lbo-call/index_spec.ts
@@ -1,0 +1,392 @@
+import { getSystemPath, normalize, virtualFs } from '@angular-devkit/core';
+import { TempScopedNodeJsSyncHost } from '@angular-devkit/core/node/testing';
+import { HostTree } from '@angular-devkit/schematics';
+import { SchematicTestRunner, UnitTestTree } from '@angular-devkit/schematics/testing/index.js';
+import { rmSync } from 'node:fs';
+
+describe('LboService.call migration', () => {
+  let runner: SchematicTestRunner;
+  let host: TempScopedNodeJsSyncHost;
+  let tree: UnitTestTree;
+  let tmpDirPath: string;
+  let previousWorkingDir: string;
+
+  function writeFile(filePath: string, contents: string) {
+    host.sync.write(normalize(filePath), virtualFs.stringToFileBuffer(contents));
+  }
+
+  function runMigration(options?: { path?: string }) {
+    return runner.runSchematic('update-lbo-call', options, tree);
+  }
+
+  beforeEach(() => {
+    runner = new SchematicTestRunner(
+      '@criticalmanufacturing/ngx-schematics',
+      require.resolve('../collection.json')
+    );
+    host = new TempScopedNodeJsSyncHost();
+    tree = new UnitTestTree(new HostTree(host));
+
+    writeFile('/tsconfig.json', '{}');
+    writeFile(
+      '/angular.json',
+      JSON.stringify({
+        version: 1,
+        projects: {
+          t: { root: '', architect: { build: { options: { tsConfig: './tsconfig.json' } } } }
+        }
+      })
+    );
+
+    // Add a cmf-core package to the test tree
+    writeFile(
+      '/node_modules/cmf-core/index.d.ts',
+      `export declare class LboService { 
+          call<T extends Cmf.Foundation.BusinessOrchestration.BaseInput>(input: T, timeout?: number): Promise<OutputOf<T>>; 
+      }`
+    );
+    writeFile(
+      '/package.json',
+      JSON.stringify({
+        dependencies: {
+          'cmf-core': '1.0.0'
+        }
+      })
+    );
+
+    previousWorkingDir = process.cwd();
+    tmpDirPath = getSystemPath(host.root);
+    process.chdir(tmpDirPath);
+  });
+
+  afterEach(() => {
+    process.chdir(previousWorkingDir);
+    rmSync(tmpDirPath, { recursive: true });
+  });
+
+  it('should update usage of LboService.call when injecting via inject()', async () => {
+    writeFile(
+      '/dir.ts',
+      [
+        `import { Component } from '@angular/core';`,
+        `import { LboService } from 'cmf-core';`,
+        ``,
+        `@Component({`,
+        `  template: '',`,
+        `})`,
+        `class TestComponent {`,
+        `  private lbo = inject(LboService);`,
+        ``,
+        `  someMethod() {`,
+        `    const input = new Cmf.Foundation.BusinessOrchestration.BaseInput();`,
+        `    const output = this.lbo.call<Cmf.Foundation.BusinessOrchestration.BaseOutput>(input);`,
+        `    return output;`,
+        `  }`,
+        `}`
+      ].join('\n')
+    );
+
+    const updatedTree = await runMigration({ path: '/dir.ts' });
+    const content = updatedTree.readContent('/dir.ts');
+
+    expect(content.split('\n')).toEqual([
+      `import { Component } from '@angular/core';`,
+      `import { LboService } from 'cmf-core';`,
+      ``,
+      `@Component({`,
+      `  template: '',`,
+      `})`,
+      `class TestComponent {`,
+      `  private lbo = inject(LboService);`,
+      ``,
+      `  someMethod() {`,
+      `    const input = new Cmf.Foundation.BusinessOrchestration.BaseInput();`,
+      `    const output = this.lbo.call(input);`,
+      `    return output;`,
+      `  }`,
+      `}`
+    ]);
+  });
+
+  it('should update usage of LboService.call when declaring property', async () => {
+    writeFile(
+      '/dir.ts',
+      [
+        `import { Component } from '@angular/core';`,
+        `import { LboService } from 'cmf-core';`,
+        ``,
+        `@Component({`,
+        `  template: '',`,
+        `})`,
+        `class TestComponent {`,
+        `  private lbo: LboService;`,
+        ``,
+        `  someMethod() {`,
+        `    const input = new Cmf.Foundation.BusinessOrchestration.BaseInput();`,
+        `    const output = this.lbo.call<Cmf.Foundation.BusinessOrchestration.BaseOutput>(input);`,
+        `    return output;`,
+        `  }`,
+        `}`
+      ].join('\n')
+    );
+
+    const updatedTree = await runMigration({ path: '/dir.ts' });
+    const content = updatedTree.readContent('/dir.ts');
+
+    expect(content.split('\n')).toEqual([
+      `import { Component } from '@angular/core';`,
+      `import { LboService } from 'cmf-core';`,
+      ``,
+      `@Component({`,
+      `  template: '',`,
+      `})`,
+      `class TestComponent {`,
+      `  private lbo: LboService;`,
+      ``,
+      `  someMethod() {`,
+      `    const input = new Cmf.Foundation.BusinessOrchestration.BaseInput();`,
+      `    const output = this.lbo.call(input);`,
+      `    return output;`,
+      `  }`,
+      `}`
+    ]);
+  });
+
+  it('should update usage of LboService.call when injecting via constructor', async () => {
+    writeFile(
+      '/dir.ts',
+      [
+        `import { Component } from '@angular/core';`,
+        `import { CustomizableComponent, LboService } from 'cmf-core';`,
+        ``,
+        `@Component({`,
+        `  template: '',`,
+        `})`,
+        `class TestComponent extends CustomizableComponent {`,
+        `  constructor(private util: any, options: any, private lbo: LboService, inputB: any) {`,
+        `     super();`,
+        `  }`,
+        ``,
+        `  someMethod() {`,
+        `    const input = new Cmf.Foundation.BusinessOrchestration.BaseInput();`,
+        `    const output = this.lbo.call<Cmf.Foundation.BusinessOrchestration.BaseOutput>(input);`,
+        `    return output;`,
+        `  }`,
+        `}`
+      ].join('\n')
+    );
+
+    const updatedTree = await runMigration({ path: '/dir.ts' });
+    const content = updatedTree.readContent('/dir.ts');
+
+    expect(content.split('\n')).toEqual([
+      `import { Component } from '@angular/core';`,
+      `import { CustomizableComponent, LboService } from 'cmf-core';`,
+      ``,
+      `@Component({`,
+      `  template: '',`,
+      `})`,
+      `class TestComponent extends CustomizableComponent {`,
+      `  constructor(private util: any, options: any, private lbo: LboService, inputB: any) {`,
+      `     super();`,
+      `  }`,
+      ``,
+      `  someMethod() {`,
+      `    const input = new Cmf.Foundation.BusinessOrchestration.BaseInput();`,
+      `    const output = this.lbo.call(input);`,
+      `    return output;`,
+      `  }`,
+      `}`
+    ]);
+  });
+
+  it('should update usage of LboService.call when passing in as parameter', async () => {
+    writeFile(
+      '/dir.ts',
+      [
+        `import { Component } from '@angular/core';`,
+        `import { LboService } from 'cmf-core';`,
+        ``,
+        `class TestUtilsService {`,
+        ``,
+        `  static someMethod(inputA: any, lbo: LboService, inputB: any) {`,
+        `    const input = new Cmf.Foundation.BusinessOrchestration.BaseInput();`,
+        `    const output = lbo.call<Cmf.Foundation.BusinessOrchestration.BaseOutput>(input);`,
+        `    return output;`,
+        `  }`,
+        `}`
+      ].join('\n')
+    );
+
+    const updatedTree = await runMigration({ path: '/dir.ts' });
+    const content = updatedTree.readContent('/dir.ts');
+
+    expect(content.split('\n')).toEqual([
+      `import { Component } from '@angular/core';`,
+      `import { LboService } from 'cmf-core';`,
+      ``,
+      `class TestUtilsService {`,
+      ``,
+      `  static someMethod(inputA: any, lbo: LboService, inputB: any) {`,
+      `    const input = new Cmf.Foundation.BusinessOrchestration.BaseInput();`,
+      `    const output = lbo.call(input);`,
+      `    return output;`,
+      `  }`,
+      `}`
+    ]);
+  });
+
+  it('should update usage of LboService.call when calling another function that returns an object with a property of type LboService', async () => {
+    writeFile(
+      '/dir.ts',
+      [
+        `import { Component } from '@angular/core';`,
+        `import { LboService } from 'cmf-core';`,
+        ``,
+        `class TestUtilsService {`,
+        ``,
+        ` static getDependencies(): { foo: string; lbo: LboService; } {`,
+        `   return { foo: 'bar', lbo: new LboService() };`,
+        ` }`,
+        ``,
+        `  static someMethod() {`,
+        `    const { lbo } = this.getDependencies();`,
+        `    const input = new Cmf.Foundation.BusinessOrchestration.BaseInput();`,
+        `    const output = lbo.call<Cmf.Foundation.BusinessOrchestration.BaseOutput>(input);`,
+        `    return output;`,
+        `  }`,
+        `}`
+      ].join('\n')
+    );
+
+    const updatedTree = await runMigration({ path: '/dir.ts' });
+    const content = updatedTree.readContent('/dir.ts');
+
+    expect(content.split('\n')).toEqual([
+      `import { Component } from '@angular/core';`,
+      `import { LboService } from 'cmf-core';`,
+      ``,
+      `class TestUtilsService {`,
+      ``,
+      ` static getDependencies(): { foo: string; lbo: LboService; } {`,
+      `   return { foo: 'bar', lbo: new LboService() };`,
+      ` }`,
+      ``,
+      `  static someMethod() {`,
+      `    const { lbo } = this.getDependencies();`,
+      `    const input = new Cmf.Foundation.BusinessOrchestration.BaseInput();`,
+      `    const output = lbo.call(input);`,
+      `    return output;`,
+      `  }`,
+      `}`
+    ]);
+  });
+
+  it('should update usage of LboService.call even when using an import alias', async () => {
+    writeFile(
+      '/dir.ts',
+      [
+        `import { Component } from '@angular/core';`,
+        `import { LboService as Service } from 'cmf-core';`,
+        ``,
+        `@Component({`,
+        `  template: '',`,
+        `})`,
+        `class TestComponent {`,
+        `  private lbo = inject(Service);`,
+        ``,
+        `  someMethod() {`,
+        `    const input = new Cmf.Foundation.BusinessOrchestration.BaseInput();`,
+        `    const output = this.lbo.call<Cmf.Foundation.BusinessOrchestration.BaseOutput>(input);`,
+        `    return output;`,
+        `  }`,
+        `}`
+      ].join('\n')
+    );
+
+    const updatedTree = await runMigration({ path: '/dir.ts' });
+    const content = updatedTree.readContent('/dir.ts');
+
+    expect(content.split('\n')).toEqual([
+      `import { Component } from '@angular/core';`,
+      `import { LboService as Service } from 'cmf-core';`,
+      ``,
+      `@Component({`,
+      `  template: '',`,
+      `})`,
+      `class TestComponent {`,
+      `  private lbo = inject(Service);`,
+      ``,
+      `  someMethod() {`,
+      `    const input = new Cmf.Foundation.BusinessOrchestration.BaseInput();`,
+      `    const output = this.lbo.call(input);`,
+      `    return output;`,
+      `  }`,
+      `}`
+    ]);
+  });
+
+  it('should update usage of LboService.call when using a property from a base class that is of type LboService', async () => {
+    writeFile(
+      '/base.ts',
+      [
+        `import { inject } from '@angular/core';`,
+        `import { LboService } from 'cmf-core';`,
+        ``,
+        `export class BaseComponent {`,
+        `  protected readonly lbo = inject(LboService);`,
+        `}`
+      ].join('\n')
+    );
+
+    writeFile(
+      '/dir.ts',
+      [
+        `import { Component } from '@angular/core';`,
+        `import { BaseComponent } from './base';`,
+        ``,
+        `@Component({`,
+        `  template: '',`,
+        `})`,
+        `class TestComponent extends BaseComponent {`,
+        ``,
+        `  someMethod() {`,
+        `    const input = new Cmf.Foundation.BusinessOrchestration.BaseInput();`,
+        `    const output = this.lbo.call<Cmf.Foundation.BusinessOrchestration.BaseOutput>(input);`,
+        `    return output;`,
+        `  }`,
+        `}`
+      ].join('\n')
+    );
+
+    const updatedTree = await runMigration();
+    const baseContent = updatedTree.readContent('/base.ts');
+    const content = updatedTree.readContent('/dir.ts');
+
+    expect(baseContent.split('\n')).toEqual([
+      `import { inject } from '@angular/core';`,
+      `import { LboService } from 'cmf-core';`,
+      ``,
+      `export class BaseComponent {`,
+      `  protected readonly lbo = inject(LboService);`,
+      `}`
+    ]);
+
+    expect(content.split('\n')).toEqual([
+      `import { Component } from '@angular/core';`,
+      `import { BaseComponent } from './base';`,
+      ``,
+      `@Component({`,
+      `  template: '',`,
+      `})`,
+      `class TestComponent extends BaseComponent {`,
+      ``,
+      `  someMethod() {`,
+      `    const input = new Cmf.Foundation.BusinessOrchestration.BaseInput();`,
+      `    const output = this.lbo.call(input);`,
+      `    return output;`,
+      `  }`,
+      `}`
+    ]);
+  });
+});

--- a/packages/schematics-devkit/migrations/update-12-0-0-lbo-call/schema.json
+++ b/packages/schematics-devkit/migrations/update-12-0-0-lbo-call/schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "UpdateLboCall",
+  "title": "Updates usage of LboService.call to no longer invoke with a generic type argument",
+  "type": "object",
+  "properties": {
+    "path": {
+      "type": "string",
+      "description": "Path relative to the project root which should be migrated",
+      "x-prompt": "Which path in your project should be migrated?",
+      "default": "./"
+    }
+  }
+}

--- a/packages/schematics-devkit/migrations/update-12-0-0-lbo-call/schema.ts
+++ b/packages/schematics-devkit/migrations/update-12-0-0-lbo-call/schema.ts
@@ -1,0 +1,6 @@
+export interface Schema {
+  /**
+   * Path relative to the project root which should be migrated.
+   */
+  path?: string;
+}


### PR DESCRIPTION
Added a migration schematic for updating usages of `LboService.call`. It removes the generic type argument that specifies the service's output. This is no longer needed because the service's output type can be inferred.