### PR TITLE
chore: version bump to 11.0.15 for 11.2.6 and 11.3.0 releases

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@criticalmanufacturing/schematics",
-  "version": "11.0.14",
+  "version": "11.0.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@criticalmanufacturing/schematics",
-      "version": "11.0.14",
+      "version": "11.0.15",
       "license": "ISC",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@criticalmanufacturing/schematics",
-  "version": "11.0.14",
+  "version": "11.0.15",
   "description": "Critical Manufacturing Angular Schematics",
   "private": true,
   "dependencies": {
@@ -37,3 +37,4 @@
     "packages/*"
   ]
 }
+


### PR DESCRIPTION
chore: version bump to 11.0.15 for 11.2.6 and 11.3.0 releases