### PR TITLE
fix: iot scaffolding fixed

### DIFF
--- a/packages/ngx-iot-schematics/src/converter/files/src/__name@dasherize__/__name@dasherize__.converter-designer.ts.template
+++ b/packages/ngx-iot-schematics/src/converter/files/src/__name@dasherize__/__name@dasherize__.converter-designer.ts.template
@@ -1,4 +1,5 @@
 import { ConverterDesigner } from 'cmf-core-connect-iot';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { Converter } from '@criticalmanufacturing/connect-iot-controller-engine';
 
 @ConverterDesigner({

--- a/packages/ngx-iot-schematics/src/converter/files/src/__name@dasherize__/__name@dasherize__.converter.ts.template
+++ b/packages/ngx-iot-schematics/src/converter/files/src/__name@dasherize__/__name@dasherize__.converter.ts.template
@@ -1,3 +1,4 @@
+/* eslint-disable  @typescript-eslint/no-explicit-any */
 import { Converter, DI, Dependencies, TYPES } from '@criticalmanufacturing/connect-iot-controller-engine';
 
 /**
@@ -17,6 +18,7 @@ export class <%= classify(name) %>Converter implements Converter.ConverterInstan
      * @param value <%= inputType %> value
      * @param parameters Transformation parameters
      */
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     transform(value: <%= inputType %>, parameters: { [key: string]: any; }): <%= outputType %> {
         // >>TODO: Add converter code
         throw new Error('>>TODO: Not implemented yet');

--- a/packages/ngx-iot-schematics/src/converter/files/test/__name@dasherize__/__name@dasherize__.converter.test.ts.template
+++ b/packages/ngx-iot-schematics/src/converter/files/test/__name@dasherize__/__name@dasherize__.converter.test.ts.template
@@ -1,9 +1,11 @@
+/* eslint-disable @typescript-eslint/ban-types */
 import 'reflect-metadata';
 import { Converter } from '@criticalmanufacturing/connect-iot-controller-engine';
-import EngineTestSuite from '@criticalmanufacturing/connect-iot-controller-engine/test';
+import EngineTestSuite from '@criticalmanufacturing/connect-iot-controller-engine/dist/test';
 import { <%= classify(name) %>Converter } from '<%= relativeTo %>/<%= dasherize(name) %>/<%= dasherize(name) %>.converter';
 
 describe('<%= nameify(name) %> converter', () => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     let converter: Converter.ConverterContainer;
 
     beforeEach(async () => {

--- a/packages/ngx-iot-schematics/src/converter/index.ts
+++ b/packages/ngx-iot-schematics/src/converter/index.ts
@@ -35,9 +35,7 @@ export default function (_options: Schema): Rule {
       throw new SchematicsException(`Converter name is required`);
     }
 
-    if (_options.path === undefined) {
-      _options.path = join(normalize(getDefaultPath(project)), 'converters');
-    }
+    _options.path = join(normalize(getDefaultPath(project)), 'converters');
 
     const parsedPath = parseName(_options.path, _options.name);
     _options.name = parsedPath.name;

--- a/packages/ngx-iot-schematics/src/library/index.ts
+++ b/packages/ngx-iot-schematics/src/library/index.ts
@@ -105,6 +105,33 @@ function updatePackagejson(options: { project: string; name: string }): Rule {
 }
 
 /**
+ * Adds "**\/*.d.ts" to ignorePatterns in the project's .eslintrc.json
+ */
+function updateEslintIgnorePatterns(options: { project: string }): Rule {
+  return async (tree: Tree) => {
+    const workspace = await readWorkspace(tree);
+    const project = workspace.projects.get(options.project);
+
+    if (!project) {
+      return;
+    }
+
+    const eslintPath = join(normalize(project.root), '.eslintrc.json');
+
+    if (!tree.exists(eslintPath)) {
+      return;
+    }
+
+    const eslintFile = new JSONFile(tree, eslintPath);
+    const existing = (eslintFile.get(['ignorePatterns']) as string[]) ?? [];
+
+    if (!existing.includes('**/*.d.ts')) {
+      eslintFile.modify(['ignorePatterns'], [...existing, '**/*.d.ts']);
+    }
+  };
+}
+
+/**
  * IoT Library generator
  */
 function addIoTLibrary(options: { project: string; skipInstall: boolean; fullname: string }) {
@@ -154,6 +181,7 @@ function addIoTLibrary(options: { project: string; skipInstall: boolean; fullnam
         name: options.fullname
       }),
       editVsCodeSettings(),
+      updateEslintIgnorePatterns({ project: options.project }),
       schematic('task', {
         path: `${sourceDir}/tasks`,
         project: options.project,

--- a/packages/ngx-iot-schematics/src/task/files/src/__name@dasherize__/__name@dasherize__-settings.component.ts.template
+++ b/packages/ngx-iot-schematics/src/task/files/src/__name@dasherize__/__name@dasherize__-settings.component.ts.template
@@ -1,3 +1,6 @@
+/* eslint-disable @angular-eslint/component-class-suffix */
+/* eslint-disable @angular-eslint/component-selector */
+/* eslint-disable  @typescript-eslint/no-explicit-any */
 import {
     Component,
     OnInit,
@@ -46,8 +49,8 @@ export interface <%= classify(name) %>TaskSettings extends <%= classify(name) %>
         BaseWidgetModule,
         PropertyContainerModule
     ],
-    templateUrl: '<%= name %>-settings.component.html',
-    <% if (style !== 'none') { %>styleUrl: './<%= name %>-settings.component.<%= style %>',<% } %>
+    templateUrl: '<%= dasherize(name) %>-settings.component.html',
+    <% if (style !== 'none') { %>styleUrl: './<%= dasherize(name) %>-settings.component.<%= style %>',<% } %>
 })
 export class <%= classify(name) %>Settings extends TaskSettingsBase implements OnInit, OnChanges {
 

--- a/packages/ngx-iot-schematics/src/task/files/src/__name@dasherize__/__name@dasherize__.task-designer.ts.template
+++ b/packages/ngx-iot-schematics/src/task/files/src/__name@dasherize__/__name@dasherize__.task-designer.ts.template
@@ -1,7 +1,8 @@
 import { Injectable } from '@angular/core';
 import { Task<% if(hasOutputs){ %>, Utilities<% } %> } from '@criticalmanufacturing/connect-iot-controller-engine';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { TaskDesigner, TaskDesignerInstance, TaskProtocol } from 'cmf-core-connect-iot';
-import { <%= classify(name) %>Settings } from './<%= name %>.task';
+import { <%= classify(name) %>Settings } from './<%= dasherize(name) %>.task';
 
 @Injectable()
 @TaskDesigner({

--- a/packages/ngx-iot-schematics/src/task/files/src/__name@dasherize__/__name@dasherize__.task.ts.template
+++ b/packages/ngx-iot-schematics/src/task/files/src/__name@dasherize__/__name@dasherize__.task.ts.template
@@ -1,3 +1,4 @@
+/* eslint-disable  @typescript-eslint/no-explicit-any */
 import {
     Task,
     Dependencies,

--- a/packages/ngx-iot-schematics/src/task/files/test/__name@dasherize__/__name@dasherize__.task.test.ts.template
+++ b/packages/ngx-iot-schematics/src/task/files/test/__name@dasherize__/__name@dasherize__.task.test.ts.template
@@ -1,9 +1,11 @@
+/* eslint-disable  @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/ban-types */
 import 'reflect-metadata';
 import * as chai from 'chai';
 import { Task } from '@criticalmanufacturing/connect-iot-controller-engine';
-import EngineTestSuite from '@criticalmanufacturing/connect-iot-controller-engine/test';
-<% if(isForProtocol === true) { %>import { DriverProxyMock } from '@criticalmanufacturing/connect-iot-controller-engine/test/mocks/driver-proxy.mock';<% } %>
-// import { DataStoreMock } from '@criticalmanufacturing/connect-iot-controller-engine/test/mocks/data-store.mock';
+import EngineTestSuite from '@criticalmanufacturing/connect-iot-controller-engine/dist/test';
+<% if(isForProtocol === true) { %>import { DriverProxyMock } from '@criticalmanufacturing/connect-iot-controller-engine/dist/test/mocks/driver-proxy.mock';<% } %>
+// import { DataStoreMock } from '@criticalmanufacturing/connect-iot-controller-engine/dist/test/mocks/data-store.mock';
 
 import { <%= classify(name) %>Settings } from '<%= relativeTo %>/<%= dasherize(name) %>/<%= dasherize(name) %>.task';
 import { <%= classify(name) %>Module } from '<%= relativeTo %>/<%= dasherize(name) %>/<%= dasherize(name) %>.task-module';
@@ -67,6 +69,7 @@ describe('<%= classify(name) %> Task tests', () => {
             // Add more links needed here...
         ],
         <% if(isForProtocol === true) { %>driverMock<% } %><% if(isForProtocol === false) { %>undefined<% } %>,
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         (containerId) => {
             // Change what you need in the container
             // Example:

--- a/packages/ngx-iot-schematics/src/task/index.ts
+++ b/packages/ngx-iot-schematics/src/task/index.ts
@@ -36,9 +36,7 @@ export default function (_options: Schema): Rule {
       throw new SchematicsException(`Task name is required`);
     }
 
-    if (_options.path === undefined) {
-      _options.path = join(normalize(getDefaultPath(project)), 'tasks');
-    }
+    _options.path = join(normalize(getDefaultPath(project)), 'tasks');
 
     const parsedPath = parseName(_options.path, _options.name);
     _options.name = parsedPath.name;


### PR DESCRIPTION
- Fixed IoT scaffolding.
- Adjusted some references to use dasherized names.
- Disabled some ESLint rules.
- Updated the converters and tasks paths to use getDefaultPath, preventing files from being created at the project root.
- Added a function to update the task library's .eslintrc.json file to ignore .d.ts files.