### PR TITLE
fix: iot angular scaffolding fixed

### DIFF
--- a/packages/ngx-iot-schematics/src/converter/files/test/__name@dasherize__/__name@dasherize__.converter.test.ts.template
+++ b/packages/ngx-iot-schematics/src/converter/files/test/__name@dasherize__/__name@dasherize__.converter.test.ts.template
@@ -1,6 +1,6 @@
 import 'reflect-metadata';
 import { Converter } from '@criticalmanufacturing/connect-iot-controller-engine';
-import EngineTestSuite from '@criticalmanufacturing/connect-iot-controller-engine/test';
+import EngineTestSuite from '@criticalmanufacturing/connect-iot-controller-engine/dist/test';
 import { <%= classify(name) %>Converter } from '<%= relativeTo %>/<%= dasherize(name) %>/<%= dasherize(name) %>.converter';
 
 describe('<%= nameify(name) %> converter', () => {

--- a/packages/ngx-iot-schematics/src/converter/index.ts
+++ b/packages/ngx-iot-schematics/src/converter/index.ts
@@ -35,9 +35,7 @@ export default function (_options: Schema): Rule {
       throw new SchematicsException(`Converter name is required`);
     }
 
-    if (_options.path === undefined) {
-      _options.path = join(normalize(getDefaultPath(project)), 'converters');
-    }
+    _options.path = join(normalize(getDefaultPath(project)), 'converters');
 
     const parsedPath = parseName(_options.path, _options.name);
     _options.name = parsedPath.name;

--- a/packages/ngx-iot-schematics/src/library/index.ts
+++ b/packages/ngx-iot-schematics/src/library/index.ts
@@ -106,6 +106,45 @@ function updatePackagejson(options: { project: string; name: string }): Rule {
 }
 
 /**
+ * Adds "**\/*.d.ts" to ignorePatterns in the project's .eslintrc.json
+ */
+function updateEslintIgnorePatterns(options: { project: string }): Rule {
+  return async (tree: Tree) => {
+    const workspace = await readWorkspace(tree);
+    const project = workspace.projects.get(options.project);
+
+    if (!project) {
+      return;
+    }
+
+    const eslintPath = join(normalize(project.root), '.eslintrc.json');
+
+    if (!tree.exists(eslintPath)) {
+      return;
+    }
+
+    const eslintFile = new JSONFile(tree, eslintPath);
+
+    // Exclude compiled declaration files from linting
+    const existingPatterns = (eslintFile.get(['ignorePatterns']) as string[]) ?? [];
+    if (!existingPatterns.includes('**/*.d.ts')) {
+      eslintFile.modify(['ignorePatterns'], [...existingPatterns, '**/*.d.ts']);
+    }
+
+    // Disable rules that are expected to fire in generated IoT library code
+    const existingRules = (eslintFile.get(['rules']) as Record<string, string>) ?? {};
+    eslintFile.modify(['rules'], {
+      ...existingRules,
+      '@angular-eslint/component-class-suffix': 'off',
+      '@angular-eslint/component-selector': 'off',
+      '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/no-unused-vars': 'off',
+      '@typescript-eslint/ban-types': 'off'
+    });
+  };
+}
+
+/**
  * IoT Library generator
  */
 function addIoTLibrary(options: { project: string; skipInstall: boolean; fullname: string }) {
@@ -155,6 +194,7 @@ function addIoTLibrary(options: { project: string; skipInstall: boolean; fullnam
         name: options.fullname
       }),
       editVsCodeSettings(),
+      updateEslintIgnorePatterns({ project: options.project }),
       schematic('task', {
         path: `${sourceDir}/tasks`,
         project: options.project,

--- a/packages/ngx-iot-schematics/src/task/files/src/__name@dasherize__/__name@dasherize__-settings.component.ts.template
+++ b/packages/ngx-iot-schematics/src/task/files/src/__name@dasherize__/__name@dasherize__-settings.component.ts.template
@@ -46,8 +46,8 @@ export interface <%= classify(name) %>TaskSettings extends <%= classify(name) %>
         BaseWidgetModule,
         PropertyContainerModule
     ],
-    templateUrl: '<%= name %>-settings.component.html',
-    <% if (style !== 'none') { %>styleUrls: ['./<%= name %>-settings.component.<%= style %>'],<% } %>
+    templateUrl: '<%= dasherize(name) %>-settings.component.html',
+    <% if (style !== 'none') { %>styleUrl: './<%= dasherize(name) %>-settings.component.<%= style %>',<% } %>
 })
 export class <%= classify(name) %>Settings extends TaskSettingsBase implements OnInit, OnChanges {
 

--- a/packages/ngx-iot-schematics/src/task/files/src/__name@dasherize__/__name@dasherize__.task-designer.ts.template
+++ b/packages/ngx-iot-schematics/src/task/files/src/__name@dasherize__/__name@dasherize__.task-designer.ts.template
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Task<% if(hasOutputs){ %>, Utilities<% } %> } from '@criticalmanufacturing/connect-iot-controller-engine';
 import { TaskDesigner, TaskDesignerInstance, TaskProtocol } from 'cmf-core-connect-iot';
-import { <%= classify(name) %>Settings } from './<%= name %>.task';
+import { <%= classify(name) %>Settings } from './<%= dasherize(name) %>.task';
 
 @Injectable()
 @TaskDesigner({

--- a/packages/ngx-iot-schematics/src/task/files/test/__name@dasherize__/__name@dasherize__.task.test.ts.template
+++ b/packages/ngx-iot-schematics/src/task/files/test/__name@dasherize__/__name@dasherize__.task.test.ts.template
@@ -1,9 +1,9 @@
 import 'reflect-metadata';
 import * as chai from 'chai';
 import { Task } from '@criticalmanufacturing/connect-iot-controller-engine';
-import EngineTestSuite from '@criticalmanufacturing/connect-iot-controller-engine/test';
-<% if(isForProtocol === true) { %>import { DriverProxyMock } from '@criticalmanufacturing/connect-iot-controller-engine/test/mocks/driver-proxy.mock';<% } %>
-// import { DataStoreMock } from '@criticalmanufacturing/connect-iot-controller-engine/test/mocks/data-store.mock';
+import EngineTestSuite from '@criticalmanufacturing/connect-iot-controller-engine/dist/test';
+<% if(isForProtocol === true) { %>import { DriverProxyMock } from '@criticalmanufacturing/connect-iot-controller-engine/dist/test/mocks/driver-proxy.mock';<% } %>
+// import { DataStoreMock } from '@criticalmanufacturing/connect-iot-controller-engine/dist/test/mocks/data-store.mock';
 
 import { <%= classify(name) %>Settings } from '<%= relativeTo %>/<%= dasherize(name) %>/<%= dasherize(name) %>.task';
 import { <%= classify(name) %>Module } from '<%= relativeTo %>/<%= dasherize(name) %>/<%= dasherize(name) %>.task-module';

--- a/packages/ngx-iot-schematics/src/task/index.ts
+++ b/packages/ngx-iot-schematics/src/task/index.ts
@@ -36,9 +36,7 @@ export default function (_options: Schema): Rule {
       throw new SchematicsException(`Task name is required`);
     }
 
-    if (_options.path === undefined) {
-      _options.path = join(normalize(getDefaultPath(project)), 'tasks');
-    }
+    _options.path = join(normalize(getDefaultPath(project)), 'tasks');
 
     const parsedPath = parseName(_options.path, _options.name);
     _options.name = parsedPath.name;


### PR DESCRIPTION
Cherry pick 
[fix: iot scaffolding fixed](https://github.com/criticalmanufacturing/ngx-schematics/pull/64)
[fix: iot scaffolding disable rules in eslint file](https://github.com/criticalmanufacturing/ngx-schematics/pull/62)

- Fixed IoT scaffolding.
- Adjusted some references to use dasherized names.
- Updated the converters and tasks paths to use getDefaultPath, preventing files from being created at the project root.
- Added a function to update the task library's .eslintrc.json file to ignore .d.ts files and disable eslint rules

